### PR TITLE
Albisteen datu egituratuetan argitaratzailea: Gamer Erauntsia -> Game Erauntsia

### DIFF
--- a/gamerauntsia/templates/berriak/berria.html
+++ b/gamerauntsia/templates/berriak/berria.html
@@ -61,7 +61,7 @@
       },
        "publisher": {
         "@type": "Organization",
-        "name": "Gamer Erauntsia",
+        "name": "Game Erauntsia",
         "logo": {
           "@type": "ImageObject",
           "url": "https://gamerauntsia.eus{{STATIC_URL}}img/logo.png",


### PR DESCRIPTION
Mastodon.eus-eko berrien joeretan (# Arakatu > Berriak) albistearen izenburuaren gainean Gamer Erauntsia jartzen zuela konturatu naiz. Uste dut zuzendu dudala.
![Screenshot 2022-05-02 at 21-21-28 Mastodon eus](https://user-images.githubusercontent.com/4741986/166312564-914f975d-1479-4c97-b875-9731735dcde1.png)
