### PR TITLE
Portadan Peertubeko bideoen iframea konpondu

### DIFF
--- a/gamerauntsia/templates/index.html
+++ b/gamerauntsia/templates/index.html
@@ -15,9 +15,9 @@
 <div class="row">
     {% get_comment_count for live as comment_count %}
     <div class="col-sm-8">
-        {% if live.get_type == 'gameplaya' or live.get_type == 'atala'  %}
+        {% if live.get_type == 'gameplaya'  %}
         <div class="flex-video widescreen">
-            <iframe width="700" height="394" src="//www.youtube.com/embed/{{live.bideoa}}" frameborder="0" allowfullscreen></iframe>
+            <iframe width="700" height="394" src="{{live.get_bideo_url}}" frameborder="0" allowfullscreen></iframe>
         </div>
         {% else %}
         <a href="{% url 'berria' live.slug %}"><img class="img-responsive" src="{{live.argazkia.get_news_frontpage_url}}"></a>
@@ -25,7 +25,7 @@
     </div>
     <div class="col-sm-4">
         <h1><a href="{{live.get_absolute_url}}">{{live.get_title}}</a></h1>
-        {% if live.get_type == 'gameplaya' or live.get_type == 'atala'  %}
+        {% if live.get_type == 'gameplaya'  %}
             <p>
                 {% if live.get_type == 'gameplaya' %}<span class="glyphicon glyphicon-play"></span> {% if live.jokoa.url %}<a href="{% url 'game' live.jokoa.slug %}">{{live.jokoa.izena}} {%if live.jokoa.bertsioa %}{{live.jokoa.bertsioa}}{% endif %}</a>{% else %}{{live.jokoa}}{% endif%} | {% endif %}{% if live.iraupena_min or live.iraupena_seg %}<span class="glyphicon glyphicon-time"></span> {{live.iraupena_min}}min {{live.iraupena_seg}}seg{% else %}<span class="label label-danger">ZUZENEKOA</span>{% endif %}{% if live.get_type == 'gameplaya' %} | <img src="{{live.plataforma.icon.get_profilesmall_url}}" alt="{{live.plataforma.izena}}" caption="{{live.plataforma.izena}}"/>{% endif %}{% if comment_count %} | <a href="{{live.get_absolute_url}}#iruzkinak">{{comment_count}} <span class="glyphicon glyphicon-comment"></span></a>{% endif %}
             </p>

--- a/gamerauntsia/views.py
+++ b/gamerauntsia/views.py
@@ -7,7 +7,6 @@ from django.shortcuts import render
 from gamerauntsia.berriak.models import Berria
 from gamerauntsia.gameplaya.models import GamePlaya
 from gamerauntsia.txapelketak.models import Txapelketa
-from gamerauntsia.getb.models import Atala
 from gamerauntsia.bazkidetza.models import Eskaintza
 
 
@@ -24,15 +23,10 @@ def index(request):
         .order_by("-pub_date")
         .select_related("argazkia")
     )
-    atala = Atala.objects.latest("pub_date")
     gp = gameplayak[0]
     berria = berriak[0]
 
-    if atala.pub_date > gp.pub_date and atala.pub_date > berria.pub_date:
-        live = atala
-        gameplayak = gameplayak[:3]
-        berriak = berriak[:8]
-    elif gp.pub_date > atala.pub_date and gp.pub_date > berria.pub_date:
+    if gp.pub_date > berria.pub_date:
         live = gp
         gameplayak = gameplayak[1:4]
         berriak = berriak[:8]


### PR DESCRIPTION
[Fix #249]
GETBko atala erakusteko aukera kentzeko aprobetxatu da, izan ere, ez da erabiltzen.